### PR TITLE
Remove To Do s

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,6 @@ The product team have provided the following acceptance tests:
 
 > I've made a list of TODOs that I would liked to have spent more time on that it would be useful for you to look over
 
-#### Unfinished items
-
-_You can search the codebase for the numbered `TODO n` item to find the code referred to_
-
-1. [ ] Implement summary component + tests (all the data is in the store already) `TODO 1`
-1. [ ] Fix the code around the payback period formatting. The test is correct, but failing `TODO 2`
-1. [ ] Please could you provide feedback on how I implemented the cost saving tests. I'm not that happy with them yet `TODO 3`
-1. [ ] Review the code in the action-items-stages component (both TypeScript and HTML) to see whether this could be simplified `TODO 4`
-1. [ ] Re-work the loading of the actions to use an API client (discuss an approach from a high-level - no actual implementation required) `TODO 5`
-
 ## How to work with the code
 
 ### Start the app

--- a/src/app/action-items/components/action-item-card/action-item-card.component.spec.ts
+++ b/src/app/action-items/components/action-item-card/action-item-card.component.spec.ts
@@ -53,8 +53,6 @@ describe('ActionItemCardComponent', () => {
     });
 
     describe('cost savings', () => {
-      // TODO 3: provide feedback on these tests
-
       it('should render a cost in US$ < 1000 as is', () => {
         setCost(999);
         assertCost('US$999');
@@ -104,7 +102,6 @@ describe('ActionItemCardComponent', () => {
       });
 
       it('should display 12 months as 1y', () => {
-        // TODO 2: this test is how the code should work - adjust the code to make this pass
         setPaybackPeriod(12);
         assertPaybackPeriod('1y');
       });
@@ -239,7 +236,6 @@ class ActionItemCardHost {
 class ActionItemPage {
   constructor(private readonly fixture: ComponentFixture<ActionItemCardHost>) {}
 
-  // TODO: improve this return type to respect `failIfNotFound`
   getElementByTestId(
     testId: string,
     failIfNotFound = true
@@ -253,7 +249,6 @@ class ActionItemPage {
     return element ?? null;
   }
 
-  // TODO: improve this return type to respect `failIfNotFound`
   getTextContentByTestId(testId: string, failIfNotFound = true): string | null {
     return (
       this.getElementByTestId(testId, failIfNotFound)?.nativeElement

--- a/src/app/action-items/components/action-item-card/action-item-card.component.ts
+++ b/src/app/action-items/components/action-item-card/action-item-card.component.ts
@@ -59,7 +59,6 @@ export class ActionItemCardComponent implements OnChanges {
       return `${paybackMonths}m`;
     } else {
       const years = Math.floor(paybackMonths / 12);
-      // TODO 2: cater for whole year case, i.e. don't render "1y, 0m", but present "1y"
       const months = paybackMonths % 12;
       return `${years}y, ${months}m`;
     }

--- a/src/app/action-items/components/action-items-stages/action-items-stages.component.ts
+++ b/src/app/action-items/components/action-items-stages/action-items-stages.component.ts
@@ -16,9 +16,6 @@ import { map } from 'rxjs/operators';
   styleUrls: ['./action-items-stages.component.css'],
 })
 export class ActionItemsStagesComponent implements OnInit {
-  // TODO 4: review the design of this component - could it be simplified -
-  // - it feels like there's a lot of repetition
-
   readonly pendingItems$ = this.store.pipe(
     select(selectActionItems('pending'))
   );
@@ -43,7 +40,6 @@ export class ActionItemsStagesComponent implements OnInit {
   constructor(private readonly store: Store<AppState>) {}
 
   ngOnInit(): void {
-    // TODO 5: move this to be fetched from the API
     this.store.dispatch(
       setActions({
         actions: {

--- a/src/app/action-items/components/action-items-summary/action-items-summary.component.html
+++ b/src/app/action-items/components/action-items-summary/action-items-summary.component.html
@@ -1,5 +1,3 @@
 <h1 style="text-align: center">
-  You have saved
-  <!-- TODO 1: compute this-->$400k of a potential
-  <!-- TODO 1: compute this-->$6.7m total
+  You have saved $400k of a potential $6.7m total
 </h1>

--- a/to-do.md
+++ b/to-do.md
@@ -1,0 +1,20 @@
+# Unfinished items (To Do's)
+1. Fix the code around the payback period formatting in the action item card. The test is correct, but failing. 
+    - /src/app/action-items/components/action-item-card/action-item-card.component.ts:57
+    - /src/app/action-items/components/action-item-card/action-item-card.component.spec.ts:104
+
+2. Implement action items summary component + tests (all the data is in the store already).
+   - /src/app/action-items/components/action-items-summary/action-items-summary.component.ts
+
+3. Improve return type of ActionItemPage.getElementByTestId() in respect of the failing case.
+    - src/app/action-items/components/action-item-card/action-item-card.component.spec.ts
+
+# Code Review
+3. Please could you provide feedback on how was the cost saving tests implemented?
+    - /src/app/action-items/components/action-item-card/action-item-card.component.spec.ts:55
+
+4. Review the code in the action-items-stages component (both TypeScript and HTML) to see whether this could be simplified as it seems there is some repetition.
+    - /src/app/action-items/components/action-items-stages/action-items-stages.component.ts
+ 
+5. Re-work the loading of the actions to use an API client (discuss an approach from a high-level - no actual implementation required).
+    - /src/app/action-items/components/action-items-stages/action-items-stages.component.ts


### PR DESCRIPTION
The To Do's are now on `to-do.ms` but they should be hidden somehow from the .zip to deliver to the candidate 30min before tech interview. Not sure how can this "hide" be done:
- PDF to share on the meeting
  - I don't like to have it separately... it will get out of sync!
- only include it in a named branch
  - Can the candidate still reach the repo, and the branch? 
  - Should we continue to have the repo public?
  - Can we "privatize" the repo keeping access to the .zip?
- encrypt?
